### PR TITLE
Fix critical bugs: manual split export and Discogs links

### DIFF
--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -11,18 +11,101 @@
     <style>
         [x-cloak] { display: none !important; }
 
+        /* Typography */
+        @font-face {
+            font-family: 'Mango Grotesque';
+            src: url('/static/fonts/MangoGrotesque-Regular.woff2') format('woff2');
+            font-weight: 400;
+            font-style: normal;
+            font-display: swap;
+        }
+
+        @font-face {
+            font-family: 'Mango Grotesque';
+            src: url('/static/fonts/MangoGrotesque-Medium.woff2') format('woff2');
+            font-weight: 600;
+            font-style: normal;
+            font-display: swap;
+        }
+
+        body {
+            font-family: 'Mango Grotesque', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        }
+
+        /* Custom Color Palette */
+        .btn-primary {
+            background-color: #E5A100;
+            color: white;
+            font-weight: 600;
+        }
+
+        .btn-primary:hover {
+            background-color: #C48800;
+        }
+
+        .btn-primary:disabled {
+            background-color: #8A8A86;
+            cursor: not-allowed;
+            opacity: 0.5;
+        }
+
+        .btn-danger {
+            background-color: #D94032;
+            color: white;
+        }
+
+        .btn-danger:hover {
+            background-color: #B02A1E;
+        }
+
+        .text-primary {
+            color: #1E1E1E;
+        }
+
+        .text-secondary {
+            color: #3D3D3D;
+        }
+
+        .text-muted {
+            color: #8A8A86;
+        }
+
+        .bg-page {
+            background-color: #F0EFEB;
+        }
+
+        .bg-card {
+            background-color: #FAF9F6;
+        }
+
+        .bg-header {
+            background-color: #121212;
+        }
+
+        .border-primary {
+            border-color: #E5A100;
+        }
+
+        .focus-primary:focus {
+            outline: none;
+            border-color: #E5A100;
+            box-shadow: 0 0 0 3px rgba(229, 161, 0, 0.1);
+        }
+
+        /* File Upload Zone */
         .file-upload-zone {
-            border: 2px dashed #cbd5e0;
+            border: 2px dashed #8A8A86;
             transition: all 0.3s;
         }
 
         .file-upload-zone.dragging {
-            border-color: #4299e1;
-            background-color: #ebf8ff;
+            border-color: #E5A100;
+            background-color: rgba(229, 161, 0, 0.05);
         }
 
+        /* Waveform */
         .waveform-container {
-            background: #f7fafc;
+            background: #FAF9F6;
             border-radius: 8px;
             padding: 16px;
         }
@@ -32,10 +115,11 @@
             top: 0;
             bottom: 0;
             width: 2px;
-            background: #f56565;
+            background: #D94032;
             opacity: 0.7;
         }
 
+        /* Album Cards */
         .album-card {
             cursor: pointer;
             transition: transform 0.2s, box-shadow 0.2s;
@@ -47,53 +131,112 @@
         }
 
         .album-card.selected {
-            border: 3px solid #4299e1;
+            border: 3px solid #E5A100;
         }
 
+        /* Queue Items */
+        .queue-item {
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .queue-item:hover {
+            background-color: #F0EFEB;
+        }
+
+        .queue-item.selected {
+            border-left: 4px solid #E5A100;
+            background-color: #FAF9F6;
+        }
+
+        /* Progress Bar */
         .progress-bar {
             transition: width 0.3s ease;
         }
+
+        .progress-bar-primary {
+            background-color: #E5A100;
+        }
+
+        /* Loading Spinner */
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        .spinner {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            border: 3px solid rgba(229, 161, 0, 0.3);
+            border-top-color: #E5A100;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+        }
     </style>
 </head>
-<body class="bg-gray-50">
+<body class="bg-page">
     <div x-data="vinylApp()" x-init="init()" class="min-h-screen">
         <!-- Header -->
-        <header class="bg-white shadow-sm border-b border-gray-200">
+        <header class="bg-header shadow-sm">
             <div class="max-w-7xl mx-auto px-4 py-4 sm:px-6 lg:px-8">
                 <div class="flex justify-between items-center">
-                    <h1 class="text-3xl font-bold text-gray-900">
+                    <h1 class="text-3xl font-bold text-white">
                         🎵 VinylFlow
                     </h1>
-                    <button @click="showSettings = !showSettings" class="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg transition">
+                    <button @click="showSettings = !showSettings" class="px-4 py-2 bg-white bg-opacity-10 hover:bg-opacity-20 text-white rounded-lg transition">
                         ⚙️ Settings
                     </button>
                 </div>
             </div>
         </header>
 
+        <!-- Intro Section -->
+        <div class="bg-card border-b" style="border-color: #3D3D3D;">
+            <div class="max-w-7xl mx-auto px-4 py-6 sm:px-6 lg:px-8 text-center">
+                <p class="text-secondary text-lg">
+                    Transform your vinyl recordings into perfectly tagged FLAC files. Upload, analyze, and match with Discogs in minutes.
+                </p>
+            </div>
+        </div>
+
         <!-- Settings Modal -->
         <div x-show="showSettings" x-cloak class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-            <div @click.away="showSettings = false" class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-                <h2 class="text-2xl font-bold mb-4">Settings</h2>
+            <div @click.away="showSettings = false" class="bg-card rounded-lg p-6 max-w-md w-full mx-4">
+                <h2 class="text-2xl font-bold text-primary mb-4">Settings</h2>
                 <div class="space-y-4">
                     <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">Silence Threshold (dB)</label>
-                        <input type="number" x-model="config.silence_threshold" class="w-full px-3 py-2 border border-gray-300 rounded-md">
+                        <label class="block text-sm font-medium text-secondary mb-1">Silence Threshold (dB)</label>
+                        <input type="number" x-model="config.silence_threshold" class="w-full px-3 py-2 border focus-primary rounded-md" style="border-color: #8A8A86;">
                     </div>
                     <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">Min Silence Duration (sec)</label>
-                        <input type="number" step="0.1" x-model="config.min_silence_duration" class="w-full px-3 py-2 border border-gray-300 rounded-md">
+                        <label class="block text-sm font-medium text-secondary mb-1">Min Silence Duration (sec)</label>
+                        <input type="number" step="0.1" x-model="config.min_silence_duration" class="w-full px-3 py-2 border focus-primary rounded-md" style="border-color: #8A8A86;">
                     </div>
                     <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">Output Directory</label>
-                        <input type="text" x-model="config.output_dir" class="w-full px-3 py-2 border border-gray-300 rounded-md">
+                        <label class="block text-sm font-medium text-secondary mb-1">Output Directory</label>
+                        <input type="text" x-model="config.output_dir" class="w-full px-3 py-2 border focus-primary rounded-md" style="border-color: #8A8A86;">
                     </div>
                     <div class="flex gap-2">
-                        <button @click="saveConfig()" class="flex-1 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600">Save</button>
-                        <button @click="showSettings = false" class="flex-1 px-4 py-2 bg-gray-300 rounded-lg hover:bg-gray-400">Cancel</button>
+                        <button @click="saveConfig()" class="flex-1 px-4 py-2 btn-primary rounded-lg">Save</button>
+                        <button @click="showSettings = false" class="flex-1 px-4 py-2 text-primary rounded-lg hover:bg-page" style="background-color: #F0EFEB;">Cancel</button>
                     </div>
                 </div>
             </div>
+        </div>
+
+        <!-- Context Menu for Waveform Splits -->
+        <div x-show="contextMenu.show"
+             x-cloak
+             @click.away="contextMenu.show = false"
+             class="fixed bg-card rounded-lg shadow-lg border z-50 py-1"
+             style="border-color: #8A8A86;"
+             :style="`left: ${contextMenu.x}px; top: ${contextMenu.y}px;`">
+            <button @click="splitAtContextMenu()"
+                    class="w-full px-4 py-2 text-left text-primary hover:bg-page flex items-center gap-2">
+                <span>✂️</span>
+                <span>Split here</span>
+            </button>
         </div>
 
         <!-- Main Container -->
@@ -102,8 +245,8 @@
                 <!-- Left Column: Upload & Queue -->
                 <div class="lg:col-span-1 space-y-6">
                     <!-- Upload Zone -->
-                    <div class="bg-white rounded-lg shadow p-6">
-                        <h2 class="text-xl font-semibold mb-4">Upload Files</h2>
+                    <div class="bg-card rounded-lg shadow p-6">
+                        <h2 class="text-xl font-semibold text-primary mb-4">Upload Files</h2>
                         <div
                             @drop.prevent="handleDrop($event)"
                             @dragover.prevent="dragging = true"
@@ -112,38 +255,53 @@
                             :class="{'dragging': dragging}"
                             class="file-upload-zone rounded-lg p-8 text-center cursor-pointer"
                         >
-                            <p class="text-gray-600 text-lg">📤 Drag & Drop audio files here</p>
-                            <p class="text-gray-400 text-sm mt-2">WAV, AIFF supported — or click to browse</p>
+                            <p class="text-secondary text-lg">📤 Drag & Drop audio files here</p>
+                            <p class="text-muted text-sm mt-2">WAV, AIFF supported — or click to browse</p>
                             <input type="file" x-ref="fileInput" @change="handleFileSelect($event)" accept=".wav,.aiff,.aif" multiple class="hidden">
+                        </div>
+
+                        <!-- Upload Progress Bar -->
+                        <div x-show="uploadProgress > 0 && uploadProgress < 100" class="mt-4">
+                            <div class="w-full bg-page rounded-full h-3 overflow-hidden">
+                                <div class="progress-bar progress-bar-primary h-3 rounded-full" :style="`width: ${uploadProgress}%`"></div>
+                            </div>
+                            <p class="text-sm text-secondary mt-2 text-center">
+                                Uploading... <span x-text="Math.round(uploadProgress)"></span>%
+                            </p>
                         </div>
                     </div>
 
                     <!-- Queue -->
-                    <div class="bg-white rounded-lg shadow p-6">
-                        <h2 class="text-xl font-semibold mb-4">Queue (<span x-text="uploadedFiles.length"></span>)</h2>
+                    <div class="bg-card rounded-lg shadow p-6">
+                        <h2 class="text-xl font-semibold text-primary mb-4">Queue (<span x-text="uploadedFiles.length"></span>)</h2>
                         <div class="space-y-2 max-h-96 overflow-y-auto">
                             <template x-for="file in uploadedFiles" :key="file.id">
-                                <div class="p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition">
+                                <div
+                                    @click="selectFile(file.id)"
+                                    class="queue-item p-3 rounded-lg transition"
+                                    :class="{'selected': file.id === currentFileId}"
+                                    style="background-color: #F0EFEB;"
+                                >
                                     <div class="flex justify-between items-start">
                                         <div class="flex-1 min-w-0">
-                                            <p class="font-medium text-sm truncate" x-text="file.filename"></p>
-                                            <p class="text-xs text-gray-500" x-text="formatSize(file.size) + ' • ' + formatDuration(file.duration)"></p>
+                                            <p class="font-medium text-sm truncate text-primary" x-text="file.filename"></p>
+                                            <p class="text-xs text-muted" x-text="formatSize(file.size) + ' • ' + formatDuration(file.duration)"></p>
                                             <p class="text-xs mt-1" :class="statusClass(file.status)" x-text="file.status"></p>
                                         </div>
-                                        <button @click="removeFile(file.id)" class="ml-2 text-red-500 hover:text-red-700">✕</button>
+                                        <button @click.stop="removeFile(file.id)" class="ml-2 btn-danger hover:opacity-80 px-2 py-1 rounded text-xs">✕</button>
                                     </div>
                                     <template x-if="file.id === currentFileId && processingProgress > 0">
                                         <div class="mt-2">
-                                            <div class="w-full bg-gray-200 rounded-full h-2">
-                                                <div class="progress-bar bg-blue-500 h-2 rounded-full" :style="`width: ${processingProgress * 100}%`"></div>
+                                            <div class="w-full bg-page rounded-full h-2">
+                                                <div class="progress-bar progress-bar-primary h-2 rounded-full" :style="`width: ${processingProgress * 100}%`"></div>
                                             </div>
-                                            <p class="text-xs text-gray-600 mt-1" x-text="processingMessage"></p>
+                                            <p class="text-xs text-secondary mt-1" x-text="processingMessage"></p>
                                         </div>
                                     </template>
                                 </div>
                             </template>
                             <template x-if="uploadedFiles.length === 0">
-                                <p class="text-gray-400 text-center py-8">No files uploaded</p>
+                                <p class="text-muted text-center py-8">No files uploaded</p>
                             </template>
                         </div>
                     </div>
@@ -152,79 +310,86 @@
                 <!-- Right Column: Main Content -->
                 <div class="lg:col-span-2 space-y-6">
                     <!-- Current File Info -->
-                    <div x-show="currentFile" x-cloak class="bg-white rounded-lg shadow p-6">
-                        <h2 class="text-2xl font-bold mb-2" x-text="currentFile?.filename"></h2>
-                        <p class="text-gray-600" x-text="formatSize(currentFile?.size) + ' • ' + formatDuration(currentFile?.duration)"></p>
+                    <div x-show="currentFile" x-cloak class="bg-card rounded-lg shadow p-6">
+                        <h2 class="text-2xl font-bold text-primary mb-2" x-text="currentFile?.filename"></h2>
+                        <p class="text-secondary" x-text="formatSize(currentFile?.size) + ' • ' + formatDuration(currentFile?.duration)"></p>
 
                         <!-- Analyze Button -->
                         <template x-if="!detectedTracks.length && currentFile">
-                            <button @click="analyzeFile()" class="mt-4 px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 font-semibold">
+                            <button @click="analyzeFile()" class="mt-4 px-6 py-3 btn-primary rounded-lg font-semibold">
                                 🔍 Analyze & Detect Tracks
                             </button>
                         </template>
 
                         <!-- Re-Analyze Button -->
                         <template x-if="detectedTracks.length > 0 && !selectedRelease">
-                            <button @click="reanalyzeFile()" class="mt-4 px-6 py-3 bg-yellow-500 text-white rounded-lg hover:bg-yellow-600 font-semibold">
+                            <button @click="reanalyzeFile()" class="mt-4 px-6 py-3 btn-primary rounded-lg font-semibold">
                                 🔄 Re-Analyze Tracks
                             </button>
                         </template>
                     </div>
 
                     <!-- Waveform Visualization -->
-                    <div x-show="detectedTracks.length > 0" x-cloak class="bg-white rounded-lg shadow p-6 mb-6">
+                    <div x-show="detectedTracks.length > 0" x-cloak class="bg-card rounded-lg shadow p-6 mb-6">
                         <div class="flex justify-between items-center mb-4">
-                            <h3 class="text-lg font-semibold">Waveform Editor</h3>
+                            <h3 class="text-lg font-semibold text-primary">Waveform Editor</h3>
                             <div class="flex gap-2">
-                                <button @click="playWaveform()" :disabled="!waveform" class="px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600 text-sm disabled:opacity-50 disabled:cursor-not-allowed">▶️ Play</button>
-                                <button @click="stopWaveform()" :disabled="!waveform" class="px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 text-sm disabled:opacity-50 disabled:cursor-not-allowed">⏹️ Stop</button>
-                                <button @click="zoomIn()" :disabled="!waveform" class="px-3 py-1 bg-gray-500 text-white rounded hover:bg-gray-600 text-sm disabled:opacity-50 disabled:cursor-not-allowed">🔍 +</button>
-                                <button @click="zoomOut()" :disabled="!waveform" class="px-3 py-1 bg-gray-500 text-white rounded hover:bg-gray-600 text-sm disabled:opacity-50 disabled:cursor-not-allowed">🔍 -</button>
+                                <button @click="playWaveform()" :disabled="!waveform" class="px-3 py-1 btn-primary rounded text-sm">▶️ Play</button>
+                                <button @click="stopWaveform()" :disabled="!waveform" class="px-3 py-1 btn-danger rounded text-sm">⏹️ Stop</button>
+                                <button @click="zoomIn()" :disabled="!waveform" class="px-3 py-1 text-white rounded text-sm" style="background-color: #3D3D3D;">🔍 +</button>
+                                <button @click="zoomOut()" :disabled="!waveform" class="px-3 py-1 text-white rounded text-sm" style="background-color: #3D3D3D;">🔍 -</button>
                             </div>
                         </div>
                         <div id="waveform" class="w-full mb-4" style="min-height: 128px;"></div>
-                        <div x-show="waveformLoading" class="text-center text-gray-600 py-4">Loading waveform...</div>
-                        <div x-show="!waveform && !waveformLoading" class="text-center text-gray-500 py-4 text-sm">Waveform will appear after analysis completes</div>
-                        <p class="text-xs text-gray-500 mt-2">💡 Tip: Drag the colored regions to adjust track boundaries</p>
+                        <div x-show="waveformLoading" class="text-center text-secondary py-4">Loading waveform...</div>
+                        <div x-show="!waveform && !waveformLoading" class="text-center text-muted py-4 text-sm">Waveform will appear after analysis completes</div>
+                        <p class="text-xs text-muted mt-2">💡 Tip: Drag the colored regions to adjust track boundaries</p>
                     </div>
 
                     <!-- Detected Tracks with Preview -->
-                    <div x-show="detectedTracks.length > 0" x-cloak class="bg-white rounded-lg shadow p-6">
-                        <h3 class="text-lg font-semibold mb-4">
+                    <div x-show="detectedTracks.length > 0" x-cloak class="bg-card rounded-lg shadow p-6">
+                        <h3 class="text-lg font-semibold text-primary mb-4">
                             Detected Tracks (<span x-text="activeTrackCount"></span> of <span x-text="detectedTracks.length"></span> active)
+                            <span x-show="detectedTracks[0]?.durationBased" class="text-xs text-muted ml-2">
+                                (Duration-based splitting)
+                            </span>
                         </h3>
-                        <div x-show="currentPlayingTrack" class="mb-4 p-4 bg-blue-50 rounded-lg">
+                        <div x-show="currentPlayingTrack" class="mb-4 p-4 rounded-lg" style="background-color: rgba(229, 161, 0, 0.1);">
                             <div class="flex items-center justify-between mb-2">
-                                <span class="font-medium text-blue-900">Playing Track <span x-text="currentPlayingTrack"></span></span>
-                                <button @click="stopPreview()" class="px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 text-sm">⏹️ Stop</button>
+                                <span class="font-medium text-primary">Playing Track <span x-text="currentPlayingTrack"></span></span>
+                                <button @click="stopPreview()" class="px-3 py-1 btn-danger rounded text-sm">⏹️ Stop</button>
                             </div>
                             <audio x-ref="audioPlayer" controls class="w-full"></audio>
                         </div>
                         <div class="space-y-3">
                             <template x-for="(track, idx) in detectedTracks" :key="idx">
-                                <div class="p-3 bg-gray-50 rounded" :class="{ 'opacity-50': track.ignored }">
+                                <div class="p-3 bg-page rounded" :class="{ 'opacity-50': track.ignored }">
                                     <div class="flex justify-between items-center mb-2">
-                                        <div class="flex items-center gap-3">
-                                            <input type="checkbox" :checked="track.ignored" @change="toggleTrackIgnored(track)" class="w-4 h-4 text-red-600 bg-gray-100 border-gray-300 rounded focus:ring-red-500" title="Ignore this track">
-                                            <button @click="playPreview(track.number)" :disabled="track.ignored" class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm disabled:bg-gray-400 disabled:cursor-not-allowed" :class="{ 'bg-blue-700': currentPlayingTrack === track.number }" title="Play 30-second preview">▶️ Play</button>
-                                            <span class="font-medium" :class="{ 'line-through text-gray-400': track.ignored }">Track <span x-text="track.number"></span></span>
+                                        <div class="flex items-center gap-2">
+                                            <input type="checkbox" :checked="track.ignored" @change="toggleTrackIgnored(track)" class="w-4 h-4 rounded" style="accent-color: #D94032;" title="Ignore this track">
+                                            <label class="text-xs text-muted cursor-pointer" @click="toggleTrackIgnored(track)">Ignore</label>
+                                            <button @click="playPreview(track.number)" :disabled="track.ignored" class="px-3 py-1 btn-primary rounded text-sm" title="Play 30-second preview">▶️ Play</button>
+                                            <span class="font-medium text-primary" :class="{ 'line-through text-muted': track.ignored }">Track <span x-text="track.number"></span></span>
                                         </div>
-                                        <button @click="track.editing = !track.editing" :disabled="track.ignored" class="px-3 py-1 bg-gray-300 rounded hover:bg-gray-400 text-sm disabled:bg-gray-200 disabled:cursor-not-allowed">
-                                            <span x-show="!track.editing">✏️ Adjust</span>
-                                            <span x-show="track.editing">✓ Done</span>
-                                        </button>
+                                        <div class="flex gap-2">
+                                            <button @click="deleteTrack(track.number)" class="px-3 py-1 btn-danger rounded text-sm" title="Delete this track">🗑️ Delete</button>
+                                            <button @click="track.editing = !track.editing" :disabled="track.ignored" class="px-3 py-1 rounded text-sm text-primary" style="background-color: #F0EFEB;" :class="{'opacity-50 cursor-not-allowed': track.ignored}">
+                                                <span x-show="!track.editing">✏️ Adjust</span>
+                                                <span x-show="track.editing">✓ Done</span>
+                                            </button>
+                                        </div>
                                     </div>
-                                    <div x-show="!track.editing" class="text-gray-600 text-sm">
+                                    <div x-show="!track.editing" class="text-secondary text-sm">
                                         <span x-text="formatTime(track.start)"></span> - <span x-text="formatTime(track.end)"></span> (<span x-text="formatDuration(track.duration)"></span>)
                                     </div>
                                     <div x-show="track.editing" class="grid grid-cols-2 gap-4 mt-2">
                                         <div>
-                                            <label class="block text-xs font-medium text-gray-700 mb-1">Start Time (seconds)</label>
-                                            <input type="number" step="0.1" :value="track.start" @input="updateTrackStart(idx, $event.target.value)" class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm">
+                                            <label class="block text-xs font-medium text-secondary mb-1">Start Time (seconds)</label>
+                                            <input type="number" step="0.1" :value="track.start" @input="updateTrackStart(idx, $event.target.value)" class="w-full px-3 py-2 border focus-primary rounded-md text-sm" style="border-color: #8A8A86;">
                                         </div>
                                         <div>
-                                            <label class="block text-xs font-medium text-gray-700 mb-1">End Time (seconds)</label>
-                                            <input type="number" step="0.1" :value="track.end" @input="updateTrackEnd(idx, $event.target.value)" class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm">
+                                            <label class="block text-xs font-medium text-secondary mb-1">End Time (seconds)</label>
+                                            <input type="number" step="0.1" :value="track.end" @input="updateTrackEnd(idx, $event.target.value)" class="w-full px-3 py-2 border focus-primary rounded-md text-sm" style="border-color: #8A8A86;">
                                         </div>
                                     </div>
                                 </div>
@@ -233,68 +398,96 @@
                     </div>
 
                     <!-- Discogs Search -->
-                    <div x-show="detectedTracks.length > 0 && !selectedRelease" x-cloak class="bg-white rounded-lg shadow p-6">
-                        <h3 class="text-lg font-semibold mb-4">🔍 Search Discogs</h3>
+                    <div x-show="detectedTracks.length > 0 && !selectedRelease" x-cloak class="bg-card rounded-lg shadow p-6">
+                        <h3 class="text-lg font-semibold text-primary mb-4">🔍 Search Discogs</h3>
                         <div class="flex gap-2 mb-4">
-                            <input type="text" x-model="searchQuery" @keyup.enter="searchDiscogs()" placeholder="Enter artist or album name..." class="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent">
-                            <button @click="searchDiscogs()" class="px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 font-semibold">Search</button>
+                            <input type="text" x-model="searchQuery" @keyup.enter="searchDiscogs()" placeholder="Enter artist or album name..." class="flex-1 px-4 py-2 border focus-primary rounded-lg" style="border-color: #8A8A86;">
+                            <button @click="searchDiscogs()" class="px-6 py-2 btn-primary rounded-lg font-semibold">Search</button>
                         </div>
-                        <div x-show="searchResults.length > 0" class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
+
+                        <!-- Loading Animation -->
+                        <div x-show="searchLoading" class="flex items-center justify-center gap-3 py-8">
+                            <div class="spinner"></div>
+                            <span class="text-secondary">Searching Discogs...</span>
+                        </div>
+
+                        <div x-show="searchResults.length > 0 && !searchLoading" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mt-4">
                             <template x-for="result in searchResults" :key="result.id">
-                                <div @click="selectRelease(result)" class="album-card bg-white border-2 border-gray-200 rounded-lg p-3 hover:shadow-lg">
-                                    <img :src="result.cover_url || ''" :alt="result.title" class="w-full aspect-square object-cover rounded mb-2 bg-gray-200" onerror="this.style.display='none'">
-                                    <p class="font-semibold text-sm truncate" x-text="result.artist"></p>
-                                    <p class="text-xs text-gray-600 truncate" x-text="result.title"></p>
-                                    <p class="text-xs text-gray-400" x-text="result.year"></p>
+                                <div @click="selectRelease(result)" class="album-card bg-card border-2 rounded-lg p-3 hover:shadow-lg" style="border-color: #8A8A86;">
+                                    <img :src="result.cover_url || ''" :alt="result.title" class="w-full aspect-square object-cover rounded mb-2" style="background-color: #F0EFEB;" onerror="this.style.display='none'">
+                                    <p class="font-semibold text-sm truncate text-primary" x-text="result.artist"></p>
+                                    <p class="text-xs text-secondary truncate" x-text="result.title"></p>
+                                    <p class="text-xs text-muted" x-text="result.year"></p>
+                                    <a @click.stop :href="`https://www.discogs.com${result.uri}`" target="_blank" rel="noopener noreferrer" class="text-xs hover:underline mt-1 inline-block" style="color: #E5A100;">View on Discogs ↗</a>
                                 </div>
                             </template>
                         </div>
                     </div>
 
                     <!-- Track Mapping -->
-                    <div x-show="selectedRelease" x-cloak class="bg-white rounded-lg shadow p-6">
+                    <div x-show="selectedRelease" x-cloak class="bg-card rounded-lg shadow p-6">
                         <div class="flex justify-between items-center mb-4">
-                            <h3 class="text-lg font-semibold">🎚️ Track Mapping</h3>
+                            <h3 class="text-lg font-semibold text-primary">🎚️ Track Mapping</h3>
                             <div class="flex gap-2">
-                                <button @click="reverseMapping()" class="px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300">↕️ Reverse</button>
-                                <button @click="selectedRelease = null; searchResults = []" class="px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300">← Back</button>
+                                <button @click="reverseMapping()" class="px-4 py-2 rounded-lg text-primary hover:bg-page" style="background-color: #F0EFEB;">↕️ Reverse</button>
+                                <button @click="selectedRelease = null; searchResults = []" class="px-4 py-2 rounded-lg text-primary hover:bg-page" style="background-color: #F0EFEB;">← Back</button>
+                            </div>
+                        </div>
+
+                        <!-- Track Count Mismatch Warning -->
+                        <div x-show="trackCountMismatch" class="mb-4 p-4 rounded-lg border-2" style="background-color: rgba(217, 64, 50, 0.1); border-color: #D94032;">
+                            <div class="flex items-start gap-3">
+                                <span class="text-2xl">⚠️</span>
+                                <div class="flex-1">
+                                    <p class="font-semibold text-primary mb-1">Track Count Mismatch</p>
+                                    <p class="text-sm text-secondary mb-2">
+                                        Detected <span class="font-semibold" x-text="detectedTracks.filter(t => !t.ignored).length"></span> tracks,
+                                        but Discogs shows <span class="font-semibold" x-text="selectedRelease?.tracks.length"></span> tracks.
+                                    </p>
+                                    <p class="text-xs text-muted">
+                                        💡 Scroll up to the waveform and right-click to add splits, or click track regions to remove them.
+                                    </p>
+                                </div>
                             </div>
                         </div>
 
                         <!-- Selected Release Info -->
-                        <div class="mb-4 p-4 bg-blue-50 rounded-lg">
-                            <p class="font-bold" x-text="`${selectedRelease.artist} - ${selectedRelease.title}`"></p>
-                            <p class="text-sm text-gray-600" x-text="`${selectedRelease.year} • ${selectedRelease.label}`"></p>
+                        <div class="mb-4 p-4 rounded-lg" style="background-color: rgba(229, 161, 0, 0.1);">
+                            <p class="font-bold text-primary" x-text="selectedRelease ? `${selectedRelease.artist} - ${selectedRelease.title}` : ''"></p>
+                            <p class="text-sm text-secondary" x-text="selectedRelease ? `${selectedRelease.year} • ${selectedRelease.label}` : ''"></p>
                         </div>
 
                         <!-- Output Format Selector -->
-                        <div class="mb-4 p-4 bg-gray-50 rounded-lg">
-                            <label class="block text-sm font-medium text-gray-700 mb-2">Output Format</label>
+                        <div class="mb-4 p-4 bg-page rounded-lg">
+                            <label class="block text-sm font-medium text-secondary mb-2">Output Format</label>
                             <div class="flex gap-3">
                                 <template x-for="fmt in availableFormats" :key="fmt.id">
-                                    <label class="flex items-center gap-2 cursor-pointer px-4 py-2 rounded-lg border-2 transition" :class="outputFormat === fmt.id ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-gray-200 hover:border-gray-300'">
-                                        <input type="radio" name="outputFormat" :value="fmt.id" x-model="outputFormat" class="hidden">
-                                        <span class="text-sm font-medium" x-text="fmt.label"></span>
-                                    </label>
+                                    <button type="button"
+                                            @click="outputFormat = fmt.id; console.log('Format selected:', fmt.id)"
+                                            class="flex items-center gap-2 cursor-pointer px-4 py-2 rounded-lg border-2 transition"
+                                            :style="outputFormat === fmt.id ? 'border-color: #E5A100; color: #E5A100; font-weight: 600;' : 'border-color: #8A8A86;'"
+                                            :class="outputFormat !== fmt.id ? 'hover:bg-card' : ''">
+                                        <span class="text-sm" x-text="fmt.label"></span>
+                                    </button>
                                 </template>
                             </div>
                         </div>
 
                         <!-- Mapping Table -->
                         <div class="space-y-2 mb-4">
-                            <div class="grid grid-cols-2 gap-4 text-sm font-semibold text-gray-700 pb-2 border-b">
+                            <div class="grid grid-cols-2 gap-4 text-sm font-semibold text-secondary pb-2" style="border-bottom: 1px solid #8A8A86;">
                                 <div>Detected Track</div>
                                 <div>Maps to Discogs Track</div>
                             </div>
                             <template x-for="(track, idx) in detectedTracks" :key="idx">
-                                <div class="grid grid-cols-2 gap-4 p-2 bg-gray-50 rounded items-center">
+                                <div class="grid grid-cols-2 gap-4 p-2 bg-page rounded items-center">
                                     <div>
-                                        <span class="font-medium">Track <span x-text="track.number"></span></span>
-                                        <span class="text-gray-600 text-sm ml-2">(<span x-text="formatDuration(track.duration)"></span>)</span>
+                                        <span class="font-medium text-primary">Track <span x-text="track.number"></span></span>
+                                        <span class="text-secondary text-sm ml-2">(<span x-text="formatDuration(track.duration)"></span>)</span>
                                     </div>
                                     <div>
-                                        <select x-model="customMapping[idx]" @change="updateCustomMapping()" class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent">
-                                            <template x-for="(dt, dtIdx) in selectedRelease.tracks" :key="dtIdx">
+                                        <select x-model="customMapping[idx]" @change="updateCustomMapping()" class="w-full px-3 py-2 border focus-primary rounded-md text-sm" style="border-color: #8A8A86;">
+                                            <template x-for="(dt, dtIdx) in (selectedRelease?.tracks || [])" :key="dtIdx">
                                                 <option :value="dtIdx" x-text="`${dt.position} - ${dt.title}`"></option>
                                             </template>
                                         </select>
@@ -304,22 +497,36 @@
                         </div>
 
                         <!-- Process Button -->
-                        <button @click="processFile()" class="w-full px-6 py-3 bg-green-500 text-white rounded-lg hover:bg-green-600 font-bold text-lg">
+                        <button @click="processFile()" class="w-full px-6 py-3 btn-primary rounded-lg font-bold text-lg">
                             ✓ Process & Save
                         </button>
                     </div>
 
                     <!-- Success Message -->
-                    <div x-show="successMessage" x-cloak class="bg-green-50 border border-green-200 rounded-lg p-6">
-                        <h3 class="text-lg font-bold text-green-800 mb-2">✓ Processing Complete!</h3>
-                        <p class="text-green-700" x-text="successMessage"></p>
-                        <button @click="resetForNextFile()" class="mt-4 px-6 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600">
+                    <div x-show="successMessage" x-cloak class="rounded-lg p-6" style="background-color: rgba(229, 161, 0, 0.1); border: 2px solid #E5A100;">
+                        <h3 class="text-lg font-bold text-primary mb-2">✓ Processing Complete!</h3>
+                        <p class="text-secondary" x-text="successMessage"></p>
+                        <button @click="resetForNextFile()" class="mt-4 px-6 py-2 btn-primary rounded-lg">
                             Process Next File
                         </button>
                     </div>
                 </div>
             </div>
         </div>
+
+        <!-- Footer -->
+        <footer class="bg-header mt-12 py-6 border-t" style="border-color: #3D3D3D;">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+                <p class="text-muted text-sm mb-2">
+                    Built with ❤️ for vinyl enthusiasts
+                </p>
+                <p class="text-sm">
+                    <a href="https://vinylflow.app/" target="_blank" class="font-semibold hover:underline" style="color: #E5A100;">vinylflow.app</a>
+                    <span class="text-muted mx-2">•</span>
+                    <span class="text-muted">© 2025 VinylFlow</span>
+                </p>
+            </div>
+        </footer>
     </div>
 
     <script src="/static/app.js"></script>

--- a/metadata_handler.py
+++ b/metadata_handler.py
@@ -75,6 +75,9 @@ class DiscogsRelease:
         self.title = release.title
         self.year = getattr(release, "year", "")
 
+        # Get URI for Discogs link - construct from release ID
+        self.uri = f"/release/{release.id}"
+
         # Get artists
         artists = getattr(release, "artists", [])
         self.artist = artists[0].name if artists else "Unknown Artist"


### PR DESCRIPTION
## Fixed Issues

1. **Manual Split Tracks Not Exporting**
   - Backend was using old track indices from initial analysis
   - When tracks were manually split, indices didn't match anymore
   - Fix: Rebuild track list from boundaries sent by frontend
   - Files: backend/api.py (added Track import, rebuilt detected_tracks logic)

2. **Discogs "View on Discogs" Links Broken**
   - python3-discogs-client doesn't return 'uri' field
   - Links went to just https://www.discogs.com
   - Fix: Construct URI from release ID: /release/{id}
   - Files: metadata_handler.py

3. **Waveform Split Position Calculation Improved**
   - Updated coordinate calculation to use scrollWidth
   - Better alignment with WaveSurfer's coordinate system
   - Files: backend/static/app.js

4. **Alpine.js Null Reference Errors**
   - Added null guards for selectedRelease properties
   - Prevents console errors when release is cleared
   - Files: backend/static/index.html

## Testing
- Manual track splitting now exports all tracks correctly
- Discogs links open correct release pages
- No Alpine errors in console