### PR TITLE
Remove output directory setting from UI — files always go to output folder

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -154,7 +154,6 @@ class ConfigUpdate(BaseModel):
     silence_threshold: Optional[float] = None
     min_silence_duration: Optional[float] = None
     min_track_length: Optional[float] = None
-    output_dir: Optional[str] = None
 
 
 # WebSocket broadcast helper
@@ -789,7 +788,6 @@ async def get_config():
         "silence_threshold": audio_processor.silence_threshold,
         "min_silence_duration": audio_processor.min_silence_duration,
         "min_track_length": audio_processor.min_track_length,
-        "output_dir": config.default_output_dir,
         "flac_compression": audio_processor.flac_compression,
     }
 
@@ -803,8 +801,6 @@ async def update_config(updates: ConfigUpdate):
         audio_processor.min_silence_duration = updates.min_silence_duration
     if updates.min_track_length is not None:
         audio_processor.min_track_length = updates.min_track_length
-    if updates.output_dir is not None:
-        config.default_output_dir = updates.output_dir
 
     return await get_config()
 

--- a/backend/static/app.js
+++ b/backend/static/app.js
@@ -61,7 +61,6 @@ function vinylApp() {
             silence_threshold: -40,
             min_silence_duration: 1.5,
             min_track_length: 30,
-            output_dir: '',
             flac_compression: 8
         },
 
@@ -165,7 +164,7 @@ function vinylApp() {
                     if (data.file_id === this.currentFileId) {
                         this.processingProgress = 1.0;
                         this.processingMessage = 'Complete!';
-                        this.successMessage = `Album saved to: ${data.output_path}\nTracks: ${data.tracks.join(', ')}`;
+                        this.successMessage = `✅ ${data.tracks.length} tracks saved to your VinylFlow/output folder\n\nTracks: ${data.tracks.join(', ')}`;
 
                         const file = this.uploadedFiles.find(f => f.id === data.file_id);
                         if (file) {
@@ -206,10 +205,12 @@ function vinylApp() {
          */
         async saveConfig() {
             try {
+                // Don't send output_dir to API
+                const { output_dir, ...configToSave } = this.config;
                 const response = await fetch('/api/config', {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(this.config)
+                    body: JSON.stringify(configToSave)
                 });
                 const data = await response.json();
                 this.config = data;

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -229,10 +229,6 @@
                         <label class="block text-sm font-medium text-secondary mb-1">Min Silence Duration (sec)</label>
                         <input type="number" step="0.1" x-model="config.min_silence_duration" class="w-full px-3 py-2 border focus-primary rounded-md" style="border-color: #8A8A86;">
                     </div>
-                    <div>
-                        <label class="block text-sm font-medium text-secondary mb-1">Output Directory</label>
-                        <input type="text" x-model="config.output_dir" class="w-full px-3 py-2 border focus-primary rounded-md" style="border-color: #8A8A86;">
-                    </div>
                     <div class="flex gap-2">
                         <button @click="saveConfig()" class="flex-1 px-4 py-2 btn-primary rounded-lg">Save</button>
                         <button @click="showSettings = false" class="flex-1 px-4 py-2 text-primary rounded-lg hover:bg-page" style="background-color: #F0EFEB;">Cancel</button>


### PR DESCRIPTION
- Remove Output Directory field from Settings modal
- Strip output_dir from config object and API payloads
- Update success message to show "VinylFlow/output folder" instead of full path
- Simplify user experience by using fixed output location