### PR TITLE
Add progress bar during Process & Save export

### DIFF
--- a/backend/static/app.js
+++ b/backend/static/app.js
@@ -58,6 +58,7 @@ function vinylApp() {
         customMapping: [],
 
         // Processing
+        isProcessing: false,
         processingProgress: 0,
         processingMessage: '',
         successMessage: '',
@@ -185,6 +186,7 @@ function vinylApp() {
                     if (data.file_id === this.currentFileId) {
                         this.processingProgress = 1.0;
                         this.processingMessage = 'Complete!';
+                        this.isProcessing = false;
                         this.successMessage = `✅ ${data.tracks.length} tracks saved to your VinylFlow/output folder\n\nTracks: ${data.tracks.join(', ')}`;
 
                         const file = this.uploadedFiles.find(f => f.id === data.file_id);
@@ -196,6 +198,7 @@ function vinylApp() {
 
                 case 'error':
                     if (data.file_id === this.currentFileId) {
+                        this.isProcessing = false;
                         this.processingMessage = `Error: ${data.message}`;
                         alert(`Processing error: ${data.message}`);
 
@@ -1250,6 +1253,7 @@ function vinylApp() {
             }));
 
             try {
+                this.isProcessing = true;
                 this.processingProgress = 0.1;
                 this.processingMessage = 'Starting...';
 
@@ -1275,6 +1279,9 @@ function vinylApp() {
                 }
             } catch (error) {
                 console.error('Processing failed:', error);
+                this.isProcessing = false;
+                this.processingProgress = 0;
+                this.processingMessage = '';
                 alert('Processing failed: ' + error.message);
             }
         },
@@ -1284,6 +1291,7 @@ function vinylApp() {
          */
         resetForNextFile() {
             this.successMessage = '';
+            this.isProcessing = false;
             this.detectedTracks = [];
             this.searchResults = [];
             this.selectedRelease = null;

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -636,9 +636,24 @@
                         </div>
 
                         <!-- Process Button -->
-                        <button @click="processFile()" class="w-full px-6 py-3 btn-primary rounded-lg font-bold text-lg">
-                            ✓ Process & Save
+                        <button @click="processFile()" :disabled="isProcessing" class="w-full px-6 py-3 btn-primary rounded-lg font-bold text-lg">
+                            <span x-show="!isProcessing">✓ Process & Save</span>
+                            <span x-show="isProcessing" class="flex items-center justify-center gap-2">
+                                <div class="spinner"></div>
+                                Processing...
+                            </span>
                         </button>
+
+                        <!-- Processing Progress -->
+                        <div x-show="isProcessing" x-cloak class="mt-4 p-4 rounded-lg" style="background-color: rgba(229, 161, 0, 0.1); border: 1px solid #E5A100;">
+                            <div class="flex items-center justify-between mb-2">
+                                <span class="text-sm font-semibold text-primary" x-text="processingMessage || 'Starting...'"></span>
+                                <span class="text-sm font-semibold" style="color: #E5A100;" x-text="Math.round(processingProgress * 100) + '%'"></span>
+                            </div>
+                            <div class="w-full bg-page rounded-full h-3 overflow-hidden">
+                                <div class="progress-bar progress-bar-primary h-3 rounded-full" :style="`width: ${processingProgress * 100}%`"></div>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Success Message -->


### PR DESCRIPTION
## Summary
- Adds a prominent progress bar with per-track status messages in the main content area during export
- Disables the "Process & Save" button while processing to prevent double-clicks
- Shows a spinner on the button with "Processing..." text during export

## Test plan
- [ ] Upload a file, analyze, select a Discogs release
- [ ] Click "Process & Save" — confirm button is disabled and shows spinner
- [ ] Confirm progress bar appears with step messages (e.g., "Processing track 3 of 8...")
- [ ] Confirm on completion, success message appears and button re-enables
- [ ] Confirm on error, button re-enables

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)