### PR TITLE
Session-based temp upload cleanup with TTL expiry and atomic deletion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,14 @@ DEFAULT_MIN_TRACK_LENGTH=30
 DEFAULT_FLAC_COMPRESSION=8
 
 # =============================================================================
+# Temporary File Management
+# =============================================================================
+# Time-to-live for uploaded files in hours
+# Files older than this will be automatically deleted
+# Default: 2 hours (files are typically processed within minutes)
+TEMP_TTL_HOURS=2
+
+# =============================================================================
 # Server Configuration (Docker only)
 # =============================================================================
 # Port for the web interface

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ temp_uploads/
 venv/
 .venv/
 output/
+config/settings.json

--- a/config.py
+++ b/config.py
@@ -67,6 +67,9 @@ class Config:
         self.default_min_track_length = float(os.getenv("DEFAULT_MIN_TRACK_LENGTH", "30"))
         self.default_flac_compression = int(os.getenv("DEFAULT_FLAC_COMPRESSION", "8"))
 
+        # Temp file management
+        self.temp_ttl_hours = float(os.getenv("TEMP_TTL_HOURS", "2"))
+
     def validate(self):
         """
         Validate configuration.
@@ -88,6 +91,9 @@ class Config:
 
         if self.default_min_track_length <= 0:
             return False, "Minimum track length must be positive"
+
+        if self.temp_ttl_hours <= 0:
+            return False, "Temp file TTL must be positive"
 
         return True, None
 
@@ -177,7 +183,8 @@ class Config:
             f"  silence_threshold={self.default_silence_threshold}dB,\n"
             f"  min_silence_duration={self.default_min_silence_duration}s,\n"
             f"  min_track_length={self.default_min_track_length}s,\n"
-            f"  flac_compression={self.default_flac_compression}\n"
+            f"  flac_compression={self.default_flac_compression},\n"
+            f"  temp_ttl_hours={self.temp_ttl_hours}h\n"
             f")"
         )
 


### PR DESCRIPTION
## Summary
This PR refactors temporary file handling to use per-upload session directories, so all artifacts for a file are grouped and cleaned up atomically.

## What changed
- Store uploads in `temp_uploads/{file_id}/source.{ext}` instead of flat `temp_uploads/`
- Store derived artifacts in the same session folder:
  - `full.mp3`
  - `peaks.json`
  - `preview_track{n}_{hash}.mp3`
- Add session helpers for path construction and one-shot cleanup
- Update queue deletion to remove entire session directory atomically
- Auto-clean session temp files after successful processing
- Add `DELETE /api/temp/clear-all` endpoint for development cleanup
  - Skips sessions currently marked as `processing`
- Replace old flat-file cleanup with session-folder TTL cleanup
  - Uses `TEMP_TTL_HOURS` (default `2`)
  - Runs every 30 minutes
- Add `TEMP_TTL_HOURS` to config loading/validation and document in `.env.example`
- Add `config/settings.json` to `.gitignore` to avoid accidental token commits

## Compatibility
- No request/response schema changes
- No WebSocket contract changes
- Frontend behavior remains unchanged (API-only integration)

## Verification
- Upload flow creates session folder + source file
- Queue delete removes full session folder
- Clear-all removes non-processing sessions and preserves processing ones
- Processing success removes session temp files automatically
- Local Docker run verified after rebuild/recreate

## Notes
- Legacy flat files already present in `temp_uploads/` are from previous behavior and can be cleaned once manually if needed.