### PR TITLE
Add Qt webview fallback for Windows installs without WebView2

### DIFF
--- a/VinylFlow.spec
+++ b/VinylFlow.spec
@@ -4,7 +4,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_all, collect_data_files
 
 
 WINDOWS_ICON = 'assets/VinylFlow.ico' if sys.platform.startswith('win') else None
@@ -22,6 +22,7 @@ DATA_FILES = [
     ('backend/static', 'backend/static'),
     *certifi_datas,
 ]
+BINARIES = [(FFMPEG_PATH, 'ffmpeg_bin')]
 
 HIDDEN_IMPORTS = [
     'backend.api',
@@ -34,9 +35,12 @@ HIDDEN_IMPORTS = [
 EXCLUDES = []
 
 if sys.platform.startswith('win'):
-    # edgechromium (WebView2) backend needs clr / pythonnet at runtime.
+    # Primary backend: edgechromium (WebView2) needs clr / pythonnet at runtime.
+    # Fallback backend: qt (pywebview's PySide6 + QtWebEngine), used on Windows
+    # installs without the WebView2 Runtime.
     HIDDEN_IMPORTS += [
         'webview.platforms.edgechromium',
+        'webview.platforms.qt',
         'clr',
         'clr_loader',
     ]
@@ -49,6 +53,19 @@ if sys.platform.startswith('win'):
         pythonnet_datas = []
     DATA_FILES += pythonnet_datas
 
+    # Bundle PySide6 + QtWebEngine so the qt fallback works without the user
+    # having to install Qt separately. collect_all gathers Qt's plugins,
+    # translations, .pak resources, QtWebEngineProcess.exe, etc.
+    try:
+        qt_datas, qt_binaries, qt_imports = collect_all('PySide6')
+        DATA_FILES += qt_datas
+        BINARIES += qt_binaries
+        HIDDEN_IMPORTS += qt_imports
+    except Exception:
+        # PySide6 not installed in the build environment — qt fallback will
+        # be unavailable in the resulting bundle, but the build still succeeds.
+        pass
+
 elif sys.platform == 'darwin':
     HIDDEN_IMPORTS.append('webview.platforms.cocoa')
 
@@ -56,7 +73,7 @@ elif sys.platform == 'darwin':
 a = Analysis(
     ['desktop_launcher.py'],
     pathex=[],
-    binaries=[(FFMPEG_PATH, 'ffmpeg_bin')],
+    binaries=BINARIES,
     datas=DATA_FILES,
     hiddenimports=HIDDEN_IMPORTS,
     hookspath=[],
@@ -92,9 +109,25 @@ coll = COLLECT(
     a.datas,
     strip=False,
     upx=True,
-    # UPX can corrupt .NET assemblies and third-party executables.
-    # ffmpeg.exe in particular can be mis-flagged by AV when UPX-packed.
-    upx_exclude=['Python.Runtime.dll', 'ffmpeg.exe'],
+    # UPX can corrupt .NET assemblies, Qt/Chromium binaries, and other
+    # third-party executables. ffmpeg.exe in particular can be mis-flagged by
+    # AV when UPX-packed; QtWebEngineProcess.exe + Qt6*.dll fail to load when
+    # compressed.
+    upx_exclude=[
+        'Python.Runtime.dll',
+        'ffmpeg.exe',
+        'QtWebEngineProcess.exe',
+        'Qt6Core.dll',
+        'Qt6Gui.dll',
+        'Qt6Widgets.dll',
+        'Qt6Network.dll',
+        'Qt6Qml.dll',
+        'Qt6WebEngineCore.dll',
+        'Qt6WebEngineWidgets.dll',
+        'Qt6WebChannel.dll',
+        'Qt6Positioning.dll',
+        'Qt6PrintSupport.dll',
+    ],
     name='VinylFlow',
 )
 app = BUNDLE(

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -18,10 +18,6 @@ from pathlib import Path
 
 import uvicorn
 
-# Must be set before `import webview` so pywebview picks up the correct backend.
-if sys.platform.startswith("win"):
-    os.environ.setdefault("PYWEBVIEW_GUI", "edgechromium")
-
 # Point requests/urllib3 at the bundled certifi CA bundle when running from a
 # PyInstaller one-folder bundle.  The runtime hook already does this, but we
 # repeat it here in case the launcher is run outside a bundle (development).
@@ -127,6 +123,37 @@ def _check_webview2_available() -> bool:
     return False
 
 
+def _check_qt_available() -> bool:
+    """Return True if a Qt + QtWebEngine binding usable by pywebview is importable."""
+    try:
+        import PySide6.QtCore  # noqa: F401
+        import PySide6.QtWebEngineWidgets  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _resolve_gui_backend() -> tuple[str | None, bool]:
+    """
+    Return (gui_name, has_backend).
+
+    gui_name is the value to pass to ``webview.start(gui=...)``; None means
+    let pywebview use its platform default (cocoa on macOS, gtk on Linux).
+    has_backend is False when no native webview is available — the caller
+    should fall back to opening the URL in the default browser.
+
+    Windows preference order: WebView2 (edgechromium) → Qt (PySide6).
+    """
+    if not sys.platform.startswith("win"):
+        return None, True
+
+    if _check_webview2_available():
+        return "edgechromium", True
+    if _check_qt_available():
+        return "qt", True
+    return None, False
+
+
 def configure_desktop_environment() -> tuple[str, int]:
     if sys.platform.startswith("win"):
         app_data_dir = _windows_app_support_dir()
@@ -212,16 +239,22 @@ def main() -> None:
         _open_browser_fallback(app_url, server_thread)
         return
 
-    # --- Windows: check WebView2 Runtime before attempting to start ---
-    if sys.platform.startswith("win") and not _check_webview2_available():
+    gui, has_backend = _resolve_gui_backend()
+    if not has_backend:
         print(
-            "[VinylFlow] Microsoft WebView2 Runtime not found.\n"
-            "  Download: https://developer.microsoft.com/microsoft-edge/webview2/\n"
+            "[VinylFlow] No native webview backend found.\n"
+            "  Install Microsoft WebView2 Runtime: https://developer.microsoft.com/microsoft-edge/webview2/\n"
             "  Opening in default browser as fallback.",
             file=sys.stderr,
         )
         _open_browser_fallback(app_url, server_thread)
         return
+
+    if gui == "qt":
+        print(
+            "[VinylFlow] WebView2 Runtime not found — using bundled Qt backend.",
+            file=sys.stderr,
+        )
 
     # --- Try native desktop window ---
     try:
@@ -233,8 +266,8 @@ def main() -> None:
             min_size=(900, 700),
             js_api=DesktopApi(),
         )
-        if sys.platform.startswith("win"):
-            webview.start(gui="edgechromium")
+        if gui:
+            webview.start(gui=gui)
         else:
             webview.start()
     except Exception as exc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,7 @@ python-multipart>=0.0.6
 websockets>=12.0
 aiofiles>=23.2.1
 pywebview>=5.1
+
+# Qt fallback backend for Windows installs without WebView2 Runtime.
+# QtWebEngine ships with PySide6, so no separate QtWebEngine package needed.
+PySide6>=6.6.0; sys_platform == 'win32'


### PR DESCRIPTION
## Summary
- Bundles PySide6 + QtWebEngine on Windows so the desktop window keeps working when the WebView2 Runtime is absent (fresh / locked-down Win10 boxes, enterprise images).
- The launcher now resolves the backend at runtime: WebView2 → Qt → browser fallback. Removes the early `PYWEBVIEW_GUI=edgechromium` env-var pin.
- Trades ~250–300 MB of bundle size for a reliable native window on any Windows machine.

## Test plan
- [ ] Trigger \`windows-release.yml\` for \`v0.2.0-beta7\`, confirm the build succeeds and the zip uploads.
- [ ] On a Windows machine **with** WebView2 Runtime: app opens in a native window as before.
- [ ] On a Windows machine **without** WebView2 Runtime (or with the \`EdgeUpdate\` reg key removed): app opens in a Qt window. Stderr shows \`WebView2 Runtime not found — using bundled Qt backend.\`
- [ ] macOS .app still builds locally (no functional change expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)